### PR TITLE
feat: configurable template path via --tpl flag and OP_ENV_TPL env var

### DIFF
--- a/bin/op-env
+++ b/bin/op-env
@@ -2,9 +2,20 @@
 # op-env: Load 1Password secrets and exec command with TTY preserved
 # Resolves all op:// references from .env.tpl in one call, exports them,
 # then exec's the given command so TTY passthrough works for interactive apps.
-# Usage: op-env <command> [args...]
+# Usage: op-env [--tpl /path/to/template] <command> [args...]
 
-TPL="${HOME}/.claude/.env.tpl"
+# Template path: --tpl flag > OP_ENV_TPL env var > default
+if [ "$1" = "--tpl" ] && [ -n "$2" ]; then
+  TPL="$2"
+  shift 2
+else
+  TPL="${OP_ENV_TPL:-${HOME}/.claude/.env.tpl}"
+fi
+
+if [ ! -f "$TPL" ]; then
+  echo "op-env: template not found: $TPL" >&2
+  exit 1
+fi
 
 # Get key names from template (skip comments and blank lines)
 KEYS=$(grep -v '^#' "$TPL" | grep -v '^$' | cut -d= -f1 | tr '\n' '|' | sed 's/|$//')


### PR DESCRIPTION
## Summary

Adds support for overriding the template path with priority resolution:
1. `--tpl /path/to/template` flag (highest priority)
2. `OP_ENV_TPL` environment variable
3. Default `~/.claude/.env.tpl` (current behavior, no breaking change)

Also adds a file-existence guard that exits with a clear error if the template is not found.

Closes #4

## Review Checklist

- [x] **R1 Fail-closed:** The new `[ ! -f "$TPL" ]` check exits 1 before reaching `exec "$@"`
- [x] **R2 Backwards compatible:** Without `--tpl` or `OP_ENV_TPL`, behavior is identical to before
- [x] **R3 Proportionate:** 11 lines added for template path flexibility + missing-file protection
- [x] **R4 No chezmoi conflict:** No new managed files — op-env is already excluded from chezmoi

## Testing

- `shellcheck bin/op-env` passes clean
- `exec "$@"` remains the last line
- Default path unchanged when no flag/env var is set