### PR TITLE
feat: report secret resolution count on launch

### DIFF
--- a/bin/op-env
+++ b/bin/op-env
@@ -2,15 +2,30 @@
 # op-env: Load 1Password secrets and exec command with TTY preserved
 # Resolves all op:// references from .env.tpl in one call, exports them,
 # then exec's the given command so TTY passthrough works for interactive apps.
-# Usage: op-env [--tpl /path/to/template] <command> [args...]
+# Usage: op-env [--tpl /path/to/template] [-q|--quiet] <command> [args...]
 
-# Template path: --tpl flag > OP_ENV_TPL env var > default
-if [ "$1" = "--tpl" ] && [ -n "$2" ]; then
-  TPL="$2"
-  shift 2
-else
-  TPL="${OP_ENV_TPL:-${HOME}/.claude/.env.tpl}"
-fi
+QUIET=0
+
+# Parse flags: --tpl and -q/--quiet (order-independent)
+while true; do
+  case "${1:-}" in
+    --tpl)
+      [ -n "${2:-}" ] || { echo "op-env: --tpl requires an argument" >&2; exit 1; }
+      TPL="$2"
+      shift 2
+      ;;
+    -q|--quiet)
+      QUIET=1
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+# Default template path if --tpl was not provided
+TPL="${TPL:-${OP_ENV_TPL:-${HOME}/.claude/.env.tpl}}"
 
 if [ ! -f "$TPL" ]; then
   echo "op-env: template not found: $TPL" >&2
@@ -18,11 +33,25 @@ if [ ! -f "$TPL" ]; then
 fi
 
 # Get key names from template (skip comments and blank lines)
-KEYS=$(grep -v '^#' "$TPL" | grep -v '^$' | cut -d= -f1 | tr '\n' '|' | sed 's/|$//')
+mapfile -t EXPECTED_KEYS < <(grep -v '^#' "$TPL" | grep -v '^$' | cut -d= -f1)
+TOTAL=${#EXPECTED_KEYS[@]}
+
+# Build pipe-separated pattern for grep
+KEYS_PATTERN=$(printf '%s|' "${EXPECTED_KEYS[@]}")
+KEYS_PATTERN="${KEYS_PATTERN%|}"
 
 # Resolve all secrets in one op call, extract only our keys, export them
+RESOLVED=0
 while IFS='=' read -r key value; do
+  if [ -n "$value" ]; then
+    RESOLVED=$((RESOLVED + 1))
+  fi
   export "$key=$value"
-done < <(op run --no-masking --env-file "$TPL" -- env 2>/dev/null | grep -E "^($KEYS)=")
+done < <(op run --no-masking --env-file "$TPL" -- env 2>/dev/null | grep -E "^($KEYS_PATTERN)=")
+
+# Print summary to stderr unless --quiet/-q
+if [ "$QUIET" -eq 0 ]; then
+  echo "op-env: ${RESOLVED}/${TOTAL} secrets resolved" >&2
+fi
 
 exec "$@"


### PR DESCRIPTION
## Summary

Prints a one-line summary to stderr after secret resolution, showing how many secrets were resolved out of the total expected from the template.

Example output: `op-env: 7/7 secrets resolved`

The summary can be suppressed with `--quiet` or `-q` for scripted usage.

Closes #5

## Review Checklist

Automated checks (B1-B3, F1-F2) run in CI. The following require manual review:

- [x] **R1 Fail-closed:** Every new error path exits before reaching `exec "$@"`. The count reporting is informational only and does not introduce new error paths -- it prints to stderr and continues to exec.
- [x] **R2 Backwards compatible:** Existing `op-env <cmd>` usage works identically without new flags. The only visible change is the new stderr summary line, which does not affect stdout or exit codes. The `-q`/`--quiet` flag is opt-in.
- [x] **R3 Proportionate:** Minimal complexity added (count variable, one conditional print). Provides immediate visibility into whether all secrets resolved successfully on every launch.
- [x] **R4 No chezmoi conflict:** Only modifies `bin/op-env`, no new files introduced.

## Testing

- `shellcheck bin/op-env` passes cleanly (zero warnings)
- Flag parsing verified: `--tpl`, `-q`, `--quiet` can appear in any order before the command
- Summary output goes to stderr only, preserving stdout for piped commands
- `exec "$@"` remains the final line of the script