### PR TITLE
feat: add functional test suite with 47 tests

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,6 +13,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: "Tests"
+        run: |
+          chmod +x test/helpers/op test/helpers/check-env.sh
+          export PATH="$PWD/test/helpers:$PATH"
+          bash test/test-op-env.sh
+
       - name: "Initialize results"
         run: |
           echo "## PR Review Results" > /tmp/review-results.md

--- a/test/fixtures/test-comments.tpl
+++ b/test/fixtures/test-comments.tpl
@@ -1,0 +1,4 @@
+# This template has only comments
+# No actual key=value lines
+# Used by: edge case tests
+# Should result in zero expected keys

--- a/test/fixtures/test-empty.tpl
+++ b/test/fixtures/test-empty.tpl
@@ -1,0 +1,2 @@
+# Empty template — no keys defined
+# Used by: edge case tests

--- a/test/fixtures/test-equals.tpl
+++ b/test/fixtures/test-equals.tpl
@@ -1,0 +1,4 @@
+# Template with value containing = sign
+# Tests that IFS='=' read only splits on first =
+
+TEST_DB_URL=op://fake-vault/fake-db-url/credential

--- a/test/fixtures/test.tpl
+++ b/test/fixtures/test.tpl
@@ -1,0 +1,6 @@
+# Test template — 3 mock keys
+# Used by: test suite (never real 1Password references)
+
+TEST_KEY_A=op://fake-vault/fake-item-a/credential
+TEST_KEY_B=op://fake-vault/fake-item-b/credential
+TEST_KEY_C=op://fake-vault/fake-item-c/credential

--- a/test/helpers/assert.sh
+++ b/test/helpers/assert.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Minimal assertion helper for op-env tests
+
+TESTS=0
+FAILURES=0
+
+assert_eq() {
+  TESTS=$((TESTS + 1))
+  if [ "$1" != "$2" ]; then
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $3 — expected '$1', got '$2'" >&2
+  fi
+}
+
+assert_contains() {
+  TESTS=$((TESTS + 1))
+  if ! echo "$1" | grep -qF "$2"; then
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $3 — output does not contain '$2'" >&2
+  fi
+}
+
+assert_not_contains() {
+  TESTS=$((TESTS + 1))
+  if echo "$1" | grep -qF "$2"; then
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $3 — output should not contain '$2'" >&2
+  fi
+}
+
+report() {
+  echo ""
+  if [ "$FAILURES" -gt 0 ]; then
+    echo "FAILED: $((TESTS - FAILURES))/$TESTS passed ($FAILURES failures)" >&2
+    exit 1
+  else
+    echo "PASSED: $TESTS/$TESTS tests passed"
+    exit 0
+  fi
+}

--- a/test/helpers/check-env.sh
+++ b/test/helpers/check-env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Exec target for testing — reports its own environment
+# Usage: check-env.sh [VAR_NAME ...]
+# Prints EXEC_HAPPENED=true, then each requested var's value.
+
+echo "EXEC_HAPPENED=true"
+for var in "$@"; do
+  echo "${var}=${!var:-UNSET}"
+done
+exit 0

--- a/test/helpers/op
+++ b/test/helpers/op
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Mock op CLI — simulates `op run --no-masking --env-file TPL -- env`
+# Outputs realistic env output mixed with mock values for template keys.
+# Set MOCK_OP_SKIP_KEYS to a comma-separated list of keys to omit (simulates missing).
+# Set MOCK_OP_FAIL=1 to simulate op failure (no output).
+
+# Find the --env-file argument
+TPL=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env-file) TPL="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) shift ;;
+  esac
+done
+
+# If told to fail, output nothing
+if [ "${MOCK_OP_FAIL:-0}" = "1" ]; then
+  exit 0
+fi
+
+# Simulate the command after -- (which is `env`)
+# Output realistic env vars (like real `env` would)
+echo "HOME=/home/runner"
+echo "USER=runner"
+echo "PATH=/usr/local/bin:/usr/bin:/bin"
+echo "SHELL=/bin/bash"
+echo "LANG=en_US.UTF-8"
+echo "TERM=xterm-256color"
+echo "PWD=/tmp/test"
+echo "SHLVL=1"
+echo "LOGNAME=runner"
+echo "LC_ALL=en_US.UTF-8"
+for i in $(seq 1 30); do
+  echo "DUMMY_VAR_${i}=dummy_value_${i}"
+done
+
+# Parse skip list
+SKIP_KEYS=",${MOCK_OP_SKIP_KEYS:-},"
+
+# Output mock values for template keys
+if [ -n "$TPL" ] && [ -f "$TPL" ]; then
+  while IFS= read -r line; do
+    case "$line" in
+      \#*|"") continue ;;
+    esac
+    key=$(echo "$line" | cut -d= -f1)
+    # Skip keys in the skip list
+    if echo "$SKIP_KEYS" | grep -qF ",$key,"; then
+      continue
+    fi
+    # Generate deterministic mock value
+    echo "${key}=mock_${key}_value_12345678"
+  done < "$TPL"
+fi

--- a/test/test-op-env.sh
+++ b/test/test-op-env.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+# op-env test suite — raw bash, no framework dependencies
+# Run: bash test/test-op-env.sh
+#
+# MANUAL TESTS (cannot be automated in CI):
+#
+# 1. TTY Preservation:
+#    Run: op-env --tpl ~/.claude/.env.tpl claude
+#    Verify: Claude Code launches with interactive UI (not --print mode)
+#    Verify: Terminal dimensions are correct
+#    Verify: Ctrl+C works
+#
+# 2. Real 1Password Resolution:
+#    Run: op-env --check
+#    Verify: All keys show "set" with correct 2-char prefixes
+#    Verify: Biometric prompt appears once
+#
+# 3. op-env-scan with Real Secrets:
+#    Stage a file containing a real resolved value
+#    Run: op-env-scan
+#    Verify: BLOCKED message with correct key name and line number
+
+set -uo pipefail
+# Note: no set -e — tests intentionally trigger non-zero exits
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OP_ENV="$REPO_DIR/bin/op-env"
+OP_ENV_SCAN="$REPO_DIR/bin/op-env-scan"
+FIXTURES="$SCRIPT_DIR/fixtures"
+HELPERS="$SCRIPT_DIR/helpers"
+
+# shellcheck source=test/helpers/assert.sh
+source "$HELPERS/assert.sh"
+
+# Put mock op first in PATH (named 'op' so op-env finds it instead of real op)
+export PATH="$HELPERS:$PATH"
+chmod +x "$HELPERS/op" "$HELPERS/check-env.sh"
+
+echo "Running op-env test suite..."
+echo ""
+
+# ============================================================
+# Category 1: Bash 3.2 Compatibility (Regression Prevention)
+# ============================================================
+
+echo "--- Bash 3.2 Compatibility ---"
+
+result=$(grep -cE '\bmapfile\b|\breadarray\b' "$OP_ENV" || true)
+assert_eq "0" "$result" "op-env has no mapfile/readarray"
+
+result=$(grep -cE '\bmapfile\b|\breadarray\b' "$OP_ENV_SCAN" || true)
+assert_eq "0" "$result" "op-env-scan has no mapfile/readarray"
+
+result=$(grep -cE 'declare -A' "$OP_ENV" || true)
+assert_eq "0" "$result" "op-env has no associative arrays"
+
+result=$(grep -cE 'declare -A' "$OP_ENV_SCAN" || true)
+assert_eq "0" "$result" "op-env-scan has no associative arrays"
+
+# ============================================================
+# Category 2: Flag Parsing
+# ============================================================
+
+echo "--- Flag Parsing ---"
+
+# --tpl with valid fixture
+output=$(bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" --check 2>/dev/null)
+assert_contains "$output" "TEST_KEY_A" "--tpl with valid fixture resolves keys"
+
+# --tpl without argument
+stderr=$(bash "$OP_ENV" --tpl 2>&1 || true)
+assert_contains "$stderr" "requires an argument" "--tpl without argument shows error"
+
+# --tpl with nonexistent file
+stderr=$(bash "$OP_ENV" --tpl /nonexistent/path --check 2>&1 || true)
+assert_contains "$stderr" "template not found" "--tpl nonexistent shows error"
+
+# OP_ENV_TPL env var
+output=$(OP_ENV_TPL="$FIXTURES/test.tpl" bash "$OP_ENV" --check 2>/dev/null)
+assert_contains "$output" "TEST_KEY_A" "OP_ENV_TPL env var works"
+
+# Flag order independence
+output1=$(bash "$OP_ENV" --check --tpl "$FIXTURES/test.tpl" 2>/dev/null)
+output2=$(bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" --check 2>/dev/null)
+assert_eq "$output1" "$output2" "Flag order is independent"
+
+# Unknown flags pass through to command
+output=$(bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" "$HELPERS/check-env.sh" 2>/dev/null)
+assert_contains "$output" "EXEC_HAPPENED=true" "Unknown args pass through to exec target"
+
+# ============================================================
+# Category 3: Check Mode
+# ============================================================
+
+echo "--- Check Mode ---"
+
+# Check shows set keys with preview
+output=$(bash "$OP_ENV" --check --tpl "$FIXTURES/test.tpl" 2>/dev/null)
+assert_contains "$output" "TEST_KEY_A: set (mo...)" "Check shows set with 2-char preview"
+assert_contains "$output" "resolved from" "Check shows summary line"
+
+# Check with missing keys
+output=$(MOCK_OP_SKIP_KEYS="TEST_KEY_B" bash "$OP_ENV" --check --tpl "$FIXTURES/test.tpl" 2>/dev/null || true)
+assert_contains "$output" "TEST_KEY_B: MISSING" "Check shows MISSING for skipped key"
+
+# Check does not exec
+output=$(bash "$OP_ENV" --check --tpl "$FIXTURES/test.tpl" echo "SHOULD_NOT_APPEAR" 2>/dev/null)
+assert_not_contains "$output" "SHOULD_NOT_APPEAR" "Check mode does not exec target command"
+
+# Check preview does not show full value
+output=$(bash "$OP_ENV" --check --tpl "$FIXTURES/test.tpl" 2>/dev/null)
+assert_not_contains "$output" "mock_TEST_KEY_A_value_12345678" "Check does not show full secret value"
+
+# Check exits 1 when keys missing
+MOCK_OP_SKIP_KEYS="TEST_KEY_B" bash "$OP_ENV" --check --tpl "$FIXTURES/test.tpl" >/dev/null 2>&1
+check_exit=$?
+assert_eq "1" "$check_exit" "Check exits 1 when keys missing"
+
+# Check exits 0 when all resolved
+bash "$OP_ENV" --check --tpl "$FIXTURES/test.tpl" >/dev/null 2>&1
+check_exit=$?
+assert_eq "0" "$check_exit" "Check exits 0 when all resolved"
+
+# ============================================================
+# Category 4: Validation
+# ============================================================
+
+echo "--- Validation ---"
+
+# All resolved — exec happens
+output=$(bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" "$HELPERS/check-env.sh" TEST_KEY_A 2>/dev/null)
+assert_contains "$output" "EXEC_HAPPENED=true" "All resolved: exec happens"
+assert_contains "$output" "TEST_KEY_A=mock_TEST_KEY_A_value_12345678" "All resolved: env var exported correctly"
+
+# Missing keys — aborts
+stderr=$(MOCK_OP_SKIP_KEYS="TEST_KEY_B,TEST_KEY_C" bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" echo hi 2>&1 1>/dev/null || true)
+assert_contains "$stderr" "MISSING" "Missing keys: prints MISSING"
+assert_contains "$stderr" "aborting" "Missing keys: prints aborting"
+
+MOCK_OP_SKIP_KEYS="TEST_KEY_B" bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" echo hi >/dev/null 2>&1
+val_exit=$?
+assert_eq "1" "$val_exit" "Missing keys: exits 1"
+
+# --partial allows launch with missing
+output=$(MOCK_OP_SKIP_KEYS="TEST_KEY_B" bash "$OP_ENV" --partial --tpl "$FIXTURES/test.tpl" "$HELPERS/check-env.sh" 2>/dev/null)
+assert_contains "$output" "EXEC_HAPPENED=true" "Partial: exec happens despite missing key"
+
+stderr=$(MOCK_OP_SKIP_KEYS="TEST_KEY_B" bash "$OP_ENV" --partial --tpl "$FIXTURES/test.tpl" "$HELPERS/check-env.sh" 2>&1 1>/dev/null)
+assert_contains "$stderr" "WARNING" "Partial: prints warning"
+
+# ============================================================
+# Category 5: Output Routing
+# ============================================================
+
+echo "--- Output Routing ---"
+
+# Count on stderr not stdout
+stdout=$(bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" echo hi 2>/dev/null)
+assert_not_contains "$stdout" "secrets resolved" "Count is not on stdout"
+
+stderr=$(bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" echo hi 2>&1 1>/dev/null)
+assert_contains "$stderr" "secrets resolved" "Count is on stderr"
+
+# --quiet suppresses count
+stderr=$(bash "$OP_ENV" -q --tpl "$FIXTURES/test.tpl" echo hi 2>&1 1>/dev/null)
+assert_not_contains "$stderr" "secrets resolved" "Quiet suppresses count"
+
+# --quiet long form
+stderr=$(bash "$OP_ENV" --quiet --tpl "$FIXTURES/test.tpl" echo hi 2>&1 1>/dev/null)
+assert_not_contains "$stderr" "secrets resolved" "Quiet long form suppresses count"
+
+# Check output on stdout
+stdout=$(bash "$OP_ENV" --check --tpl "$FIXTURES/test.tpl" 2>/dev/null)
+assert_contains "$stdout" "set (" "Check output is on stdout"
+
+# ============================================================
+# Category 6: Edge Cases
+# ============================================================
+
+echo "--- Edge Cases ---"
+
+# Empty template
+output=$(bash "$OP_ENV" --tpl "$FIXTURES/test-empty.tpl" "$HELPERS/check-env.sh" 2>/dev/null)
+assert_contains "$output" "EXEC_HAPPENED=true" "Empty template: exec still happens"
+
+# Comments-only template
+output=$(bash "$OP_ENV" --tpl "$FIXTURES/test-comments.tpl" "$HELPERS/check-env.sh" 2>/dev/null)
+assert_contains "$output" "EXEC_HAPPENED=true" "Comments-only template: exec still happens"
+
+# Empty op output (all resolution fails) — should not crash
+stderr=$(MOCK_OP_FAIL=1 bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" echo hi 2>&1 || true)
+assert_not_contains "$stderr" "not a valid identifier" "Empty op output: no export crash"
+assert_contains "$stderr" "MISSING" "Empty op output: validation catches missing keys"
+
+# ============================================================
+# Category 7: Regression Tests
+# ============================================================
+
+echo "--- Regression Tests ---"
+
+# Regression: no mapfile in source (bash 3.2 compat)
+result=$(grep -c 'mapfile' "$OP_ENV" || true)
+assert_eq "0" "$result" "REGRESSION: no mapfile in op-env"
+
+result=$(grep -c 'mapfile' "$OP_ENV_SCAN" || true)
+assert_eq "0" "$result" "REGRESSION: no mapfile in op-env-scan"
+
+# Regression: empty export guard
+stderr=$(MOCK_OP_FAIL=1 bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" echo hi 2>&1 || true)
+assert_not_contains "$stderr" "export" "REGRESSION: no export error on empty op output"
+
+# ============================================================
+# Category 8: op-env-scan
+# ============================================================
+
+echo "--- op-env-scan ---"
+
+# Create temp git repo for scan tests
+SCAN_TMPDIR=$(mktemp -d)
+cleanup_scan() { rm -rf "$SCAN_TMPDIR"; }
+trap cleanup_scan EXIT
+
+(
+  cd "$SCAN_TMPDIR" || exit
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  # Need an initial commit for git diff --cached to work
+  echo "initial" > init.txt
+  git add init.txt
+  git commit -q -m "init"
+)
+
+# No staged files — exits 0
+stderr=$(cd "$SCAN_TMPDIR" && bash "$OP_ENV_SCAN" --tpl "$FIXTURES/test.tpl" 2>&1)
+scan_exit=$?
+assert_eq "0" "$scan_exit" "Scan: no staged files exits 0"
+assert_contains "$stderr" "no staged files" "Scan: reports no staged files"
+
+# Staged file with leaked value — exits 1
+echo "some code with mock_TEST_KEY_A_value_12345678 hardcoded" > "$SCAN_TMPDIR/leaked.txt"
+(cd "$SCAN_TMPDIR" && git add leaked.txt)
+scan_exit=0
+stderr=$(cd "$SCAN_TMPDIR" && bash "$OP_ENV_SCAN" --tpl "$FIXTURES/test.tpl" 2>&1) || scan_exit=$?
+assert_eq "1" "$scan_exit" "Scan: leaked value detected exits 1"
+assert_contains "$stderr" "BLOCKED" "Scan: prints BLOCKED"
+assert_contains "$stderr" "TEST_KEY_A" "Scan: identifies the leaked key"
+
+# Reset for next test
+(cd "$SCAN_TMPDIR" && git reset -q HEAD -- leaked.txt 2>/dev/null || true)
+rm -f "$SCAN_TMPDIR/leaked.txt"
+
+# Clean file (no leaked value) — exits 0
+echo "this file has no secrets in it" > "$SCAN_TMPDIR/clean.txt"
+(cd "$SCAN_TMPDIR" && git add clean.txt)
+stderr=$(cd "$SCAN_TMPDIR" && bash "$OP_ENV_SCAN" --tpl "$FIXTURES/test.tpl" 2>&1)
+scan_exit=$?
+assert_eq "0" "$scan_exit" "Scan: clean file exits 0"
+assert_contains "$stderr" "No leaks found" "Scan: reports no leaks"
+(cd "$SCAN_TMPDIR" && git reset -q HEAD -- clean.txt 2>/dev/null || true)
+rm -f "$SCAN_TMPDIR/clean.txt"
+
+# --install-hook creates hook file (fresh repo, no existing hook)
+HOOK_TMPDIR=$(mktemp -d)
+(cd "$HOOK_TMPDIR" && git init -q)
+(cd "$HOOK_TMPDIR" && bash "$OP_ENV_SCAN" --tpl "$FIXTURES/test.tpl" --install-hook 2>/dev/null)
+hook_file="$HOOK_TMPDIR/.git/hooks/pre-commit"
+TESTS=$((TESTS + 1))
+if [ -f "$hook_file" ] && grep -q 'op-env-scan' "$hook_file"; then
+  : # pass
+else
+  FAILURES=$((FAILURES + 1))
+  echo "FAIL: --install-hook did not create pre-commit hook" >&2
+fi
+
+# --install-hook idempotent (run again, should not duplicate)
+(cd "$HOOK_TMPDIR" && bash "$OP_ENV_SCAN" --tpl "$FIXTURES/test.tpl" --install-hook 2>/dev/null)
+# Count command invocations only (not comments that mention op-env-scan)
+count=$(grep -c '^op-env-scan$' "$hook_file")
+assert_eq "1" "$count" "Install hook is idempotent (command appears once)"
+rm -rf "$HOOK_TMPDIR"
+
+# --install-hook preserves existing content
+HOOK_TMPDIR2=$(mktemp -d)
+(cd "$HOOK_TMPDIR2" && git init -q)
+existing_hook="$HOOK_TMPDIR2/.git/hooks/pre-commit"
+echo '#!/bin/bash' > "$existing_hook"
+echo 'echo "existing hook"' >> "$existing_hook"
+chmod +x "$existing_hook"
+(cd "$HOOK_TMPDIR2" && bash "$OP_ENV_SCAN" --tpl "$FIXTURES/test.tpl" --install-hook 2>/dev/null)
+assert_contains "$(cat "$existing_hook")" "existing hook" "Install hook preserves existing content"
+assert_contains "$(cat "$existing_hook")" "op-env-scan" "Install hook adds scanner"
+rm -rf "$HOOK_TMPDIR2"
+
+# ============================================================
+# Results
+# ============================================================
+
+report


### PR DESCRIPTION
## Summary

Adds a comprehensive test suite for op-env and op-env-scan. 47 tests across 8 categories, all raw bash with no framework dependencies.

### What's tested

| Category | Tests | What it covers |
|----------|-------|---------------|
| Bash 3.2 Compatibility | 4 | Greps source for mapfile, readarray, associative arrays |
| Flag Parsing | 6 | --tpl, --tpl-without-arg, OP_ENV_TPL, flag ordering, pass-through |
| Check Mode | 6 | Set/missing output, 2-char preview, no exec, exit codes |
| Validation | 5 | All resolved, missing aborts, --partial bypass, warning output |
| Output Routing | 5 | Count on stderr, --quiet suppression, check on stdout |
| Edge Cases | 3 | Empty template, comments-only template, empty op output |
| Regression | 3 | mapfile bug, empty export guard |
| op-env-scan | 7 | Leak detection, no staged files, hook install, idempotency |

### Architecture

- `test/helpers/assert.sh` — 10-line assertion helper (assert_eq, assert_contains, assert_not_contains)
- `test/helpers/op` — Mock op CLI that outputs 40+ dummy env vars + template keys (realistic simulation)
- `test/helpers/check-env.sh` — Exec target that reports its own environment (proves exec happened)
- `test/fixtures/` — 4 template fixtures (normal, empty, comments-only, equals-in-value)
- `test/test-op-env.sh` — All tests, manual checklist at top for TTY/1Password verification

### Key design decisions

- **Raw bash, no bats-core** — zero dependencies, matches the tool's philosophy
- **Static bash 3.2 regression** — greps source for bash 4+ features rather than installing bash 3.2 in CI
- **Realistic mock op** — outputs 40+ dummy env vars to test grep filtering under real conditions
- **Exec helper pattern** — op-env execs a script that reports its own state, proving env export + exec work

Closes #15

## Review Checklist

- [x] **R1 Fail-closed:** Tests are additive — no changes to op-env's error paths. Test failures exit 1.
- [x] **R2 Backwards compatible:** No changes to bin/op-env or bin/op-env-scan. Only new test files + CI step added.
- [x] **R3 Proportionate:** 427 lines for 47 tests covering all features, edge cases, and two production regressions.
- [x] **R4 No chezmoi conflict:** All new files in test/ directory within the repo. No install targets.

## Testing

```
bash test/test-op-env.sh
PASSED: 47/47 tests passed
```