### PR TITLE
feat: add --version / -v flag

### DIFF
--- a/bin/op-env
+++ b/bin/op-env
@@ -4,6 +4,8 @@
 # then exec's the given command so TTY passthrough works for interactive apps.
 # Usage: op-env [--tpl /path/to/template] [--check] [--partial] [-q|--quiet] <command> [args...]
 
+VERSION="0.2.0"
+
 CHECK=0
 QUIET=0
 PARTIAL=0
@@ -27,6 +29,10 @@ while true; do
     -q|--quiet)
       QUIET=1
       shift
+      ;;
+    -v|--version)
+      echo "op-env $VERSION" >&2
+      exit 0
       ;;
     *)
       break

--- a/test/test-op-env.sh
+++ b/test/test-op-env.sh
@@ -64,6 +64,18 @@ assert_eq "0" "$result" "op-env-scan has no associative arrays"
 
 echo "--- Flag Parsing ---"
 
+# --version prints version and exits 0
+stderr=$(bash "$OP_ENV" --version 2>&1 1>/dev/null)
+assert_contains "$stderr" "op-env 0." "--version prints version string"
+
+ver_exit=0
+bash "$OP_ENV" --version >/dev/null 2>&1 || ver_exit=$?
+assert_eq "0" "$ver_exit" "--version exits 0"
+
+# -v short form
+stderr=$(bash "$OP_ENV" -v 2>&1 1>/dev/null)
+assert_contains "$stderr" "op-env 0." "-v prints version string"
+
 # --tpl with valid fixture
 output=$(bash "$OP_ENV" --tpl "$FIXTURES/test.tpl" --check 2>/dev/null)
 assert_contains "$output" "TEST_KEY_A" "--tpl with valid fixture resolves keys"


### PR DESCRIPTION
## Summary

Adds `--version` and `-v` flags that print `op-env VERSION` to stderr and exit 0. Starting at v0.2.0 reflecting features shipped since the initial script.

3 new tests added (50 total).

Closes #14

## Review Checklist

- [x] **R1 Fail-closed:** `--version` exits 0 before reaching resolution or exec. No new error paths.
- [x] **R2 Backwards compatible:** New flag only — no existing behavior changed.
- [x] **R3 Proportionate:** 5 lines added to op-env (VERSION var + case branch). 3 tests added.
- [x] **R4 No chezmoi conflict:** Only bin/op-env and test file modified.

## Testing

```
bash test/test-op-env.sh
PASSED: 50/50 tests passed
```