### PR TITLE
feat(install): harden install.sh and add installation test suite

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,6 +19,11 @@ jobs:
           export PATH="$PWD/test/helpers:$PATH"
           bash test/test-op-env.sh
 
+      - name: "Installation tests"
+        run: |
+          chmod +x test/helpers/op test/helpers/check-env.sh
+          bash test/test-install.sh
+
       - uses: oven-sh/setup-bun@v2
 
       - name: "Docs-sync validation"
@@ -39,7 +44,7 @@ jobs:
           sudo apt-get install -y shellcheck > /dev/null 2>&1
           output=""
           failed=false
-          for f in bin/*; do
+          for f in bin/* install.sh; do
             [ -f "$f" ] || continue
             if result=$(shellcheck "$f" 2>&1); then
               output="$output $f clean"
@@ -60,7 +65,7 @@ jobs:
         id: b1
         continue-on-error: true
         run: |
-          added_code=$(git diff origin/main --unified=0 -- 'bin/*' | grep '^\+' | grep -v '^\+\+\+' | grep -v '^\+\s*#' || true)
+          added_code=$(git diff origin/main --unified=0 -- 'bin/*' 'install.sh' | grep '^\+' | grep -v '^\+\+\+' | grep -v '^\+\s*#' || true)
           if [ -z "$added_code" ]; then
             echo "| B1 | BLOCKING | PASS | No added code lines to check |" >> /tmp/review-results.md
             exit 0

--- a/Plans/dev-prod-separation-2026-03-27.md
+++ b/Plans/dev-prod-separation-2026-03-27.md
@@ -1,0 +1,99 @@
+---
+title: Dev/Prod Separation with TDD Test Plan and CI/CD Audit
+status: complete
+created: 2026-03-27
+author: Daesa (PAI)
+priority: high
+scope: install.sh hardening, installation tests, CI/CD coverage expansion
+related-issue: broken symlink at ~/.local/bin/op-env after dev directory rename
+---
+
+# Dev/Prod Separation with TDD Test Plan
+
+## Context
+
+Drew's `op-env` production binary at `~/.local/bin/op-env` is a broken symlink pointing to the old dev directory path (`~/projects/dev-tools/op-env/bin/op-env`). The directory was renamed to `op-env-dev`. The `install.sh` script correctly uses `cp` (not symlink), but the symlink was likely created manually at some point, bypassing install.sh.
+
+**Goal:** The dev directory is purely for development. The production binary is an independent copy deployed by running `install.sh` after releases. CI/CD validates that the installation process works correctly. No future directory rename or dev-side change should ever break the production binary.
+
+**CI/CD audit findings:**
+- `pr-check.yml` B1 (exfiltration) and B3 (shellcheck) only scan `bin/*` — install.sh is not covered
+- No test covers install.sh behavior (file type, version baking, permissions)
+- `release.yml` only runs release-please — no post-release installation verification
+- F2 allowlist already includes `readlink`, `realpath`, `rm`, `ln` — no flags expected from our changes
+
+**First Principles insight:** The architecture was already correct — `install.sh` uses `cp`. The gap was enforcement and verification. Nothing tested that install.sh produces a standalone binary, nothing caught when a manual symlink bypassed it. The fix is tests and hardening, not redesign.
+
+## Plan
+
+### Step 1: Harden install.sh (3 surgical changes)
+
+**File:** `install.sh`
+
+1. **Symlink detection and removal** — before the `cp`, check if the destination is a symlink and remove it. Prevents `cp` from following the symlink and writing to the wrong place.
+
+2. **Readlink-safety** — resolve install.sh's own path through symlinks using macOS-compatible `readlink` (NOT `readlink -f` which doesn't exist on macOS). Same pattern as `bin/op-env` line 8: `SCRIPT_REAL=$(readlink "$0" 2>/dev/null || echo "$0")`.
+
+3. **Version bake verification** — after the sed, grep the installed file to confirm the bake succeeded. If the original `cat "$SCRIPT_DIR/../version.txt"` pattern still exists in the installed copy, fail loudly rather than silently deploying a broken version.
+
+### Step 2: Write TDD Tests — New file `test/test-install.sh`
+
+Uses the same `assert.sh` helper library and raw-bash test pattern as `test-op-env.sh`. All tests run in an isolated temp directory (`INSTALL_DIR=$(mktemp -d)`) and clean up after themselves.
+
+**Unit tests (8):**
+1. install.sh creates target as regular file (not symlink)
+2. install.sh overwrites existing symlink with regular file
+3. install.sh overwrites existing regular file (upgrade path)
+4. Installed binary has executable permissions
+5. Version is baked into installed copy (grep for `echo "VERSION"`)
+6. Installed binary does NOT contain `version.txt` read pattern
+7. install.sh creates target directory if missing
+8. install.sh works from any working directory (run from `/tmp`)
+
+**Functional tests (5):**
+9. Installed `op-env --version` outputs correct version string
+10. Installed `op-env --help` exits 0 with usage text
+11. Installed `op-env` with mock `op` resolves template keys
+12. Installed `op-env` fails gracefully when `op` not found
+13. Installed binary's `exec "$@"` is last non-comment line (TTY preserved)
+
+### Step 3: Extend CI/CD — Modify `pr-check.yml`
+
+Three changes:
+
+1. **Add installation test step** — new step after "Tests" that runs `test/test-install.sh` in an isolated temp dir on every PR.
+
+2. **Extend B3 shellcheck to cover install.sh** — add `install.sh` to the file list alongside `bin/*`.
+
+3. **Extend B1 exfiltration check to cover install.sh** — change git diff pattern from `-- 'bin/*'` to `-- 'bin/*' 'install.sh'`. Defense-in-depth.
+
+### Step 4: Fix the immediate broken symlink
+
+Run `install.sh` to replace the broken symlink with a standalone copy. The hardened install.sh will detect the symlink, remove it, and install a proper copy.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `install.sh` | Harden: symlink detection, readlink-safety, bake verification |
+| `test/test-install.sh` | **NEW**: 13 tests for install.sh (unit + functional) |
+| `.github/workflows/pr-check.yml` | Add install test step, extend B3 + B1 scope |
+
+## Files NOT Modified
+
+| File | Why |
+|------|-----|
+| `bin/op-env` | Already symlink-safe, no changes needed |
+| `bin/op-env-scan` | Not related |
+| `test/test-op-env.sh` | Existing 56 tests untouched |
+| `.github/workflows/release.yml` | release-please config unchanged |
+
+## Verification Checklist
+
+- [ ] Existing test suite passes: `bash test/test-op-env.sh` (all 56 tests)
+- [ ] New install tests pass: `bash test/test-install.sh` (all 13 tests)
+- [ ] Shellcheck passes on install.sh: `shellcheck install.sh`
+- [ ] Run `./install.sh` on Drew's machine — replaces broken symlink
+- [ ] `op-env --version` outputs `0.3.0`
+- [ ] `ls -la ~/.local/bin/op-env` shows regular file, not symlink
+- [ ] pr-check.yml B1 and B3 scope includes install.sh (expanded, not weakened)

--- a/Plans/release-first-pipeline-2026-03-27.md
+++ b/Plans/release-first-pipeline-2026-03-27.md
@@ -1,0 +1,137 @@
+---
+title: Release-First Pipeline Pattern
+status: planned
+created: 2026-03-27
+author: Daesa (PAI)
+priority: high
+scope: install.sh guard, release workflow artifact publishing, update mechanism
+depends-on: feat/install-hardening PR merge
+pattern-test: op-env (first project to test this pattern)
+github-issue: TBD (will be linked after creation)
+---
+
+# Release-First Pipeline Pattern
+
+## Why This Pattern
+
+On 2026-03-27, a broken symlink at `~/.local/bin/op-env` caused all Claude Code aliases to fail. Root cause: the production binary was a symlink pointing into the dev working tree, not a standalone copy from a release. Renaming the dev directory broke production.
+
+**Lesson:** Production binaries should never depend on the dev working tree. They should come exclusively from releases.
+
+**This pattern is being tested with op-env first.** If it works well, it can be applied to other projects in `~/projects/dev-tools/`.
+
+## Current State (after install-hardening PR)
+
+- install.sh uses `cp` (correct) with symlink detection and readlink-safety
+- 14 installation tests validate install.sh behavior
+- CI covers install.sh via shellcheck and exfiltration scans
+- But: install.sh can still be run from any commit, including dirty working trees
+
+## Release-First Pipeline Design
+
+### Component 1: install.sh Guard
+
+**What:** install.sh checks if it's running from a tagged release commit. If not, it warns and requires `--dev` flag to proceed.
+
+**Why:** Prevents accidental production installs from development state. The `--dev` flag is an explicit "I know what I'm doing" signal.
+
+**How:**
+```bash
+# After set -e, before any work
+TAG=$(git -C "$SCRIPT_DIR" describe --exact-match HEAD 2>/dev/null || true)
+if [ -z "$TAG" ] && [ "$1" != "--dev" ]; then
+  echo "WARNING: Not a tagged release. Use './install.sh --dev' to install from development." >&2
+  echo "For production installs, download from GitHub releases." >&2
+  exit 1
+fi
+```
+
+**Edge cases:**
+- First-time users cloning from a tagged release: works (tag present)
+- First-time users cloning main after a release: no tag on HEAD, must use `--dev`
+- CI tests: already use temp dirs with HOME override, not install.sh directly from repo — unaffected
+- test-install.sh: runs install.sh via `bash install.sh`, not `./install.sh` — needs `--dev` flag added to test helper
+
+### Component 2: Release Workflow Binary Publishing
+
+**What:** Enhance `release.yml` to attach a production-ready binary as a release asset after release-please creates the release.
+
+**Why:** Makes the release the single source of truth for production binaries. Users download from releases, not from git clone.
+
+**How:** Add a second job to `release.yml` that runs after `release-please`:
+```yaml
+  publish-binary:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build production binary
+        run: |
+          VERSION=$(cat version.txt)
+          cp bin/op-env op-env-v${VERSION}
+          chmod +x op-env-v${VERSION}
+          # Bake version
+          sed -i "s|cat \"\$SCRIPT_DIR/../version.txt\" 2>/dev/null|echo \"$VERSION\"|" op-env-v${VERSION}
+          # Verify bake
+          if grep -q 'cat "\$SCRIPT_DIR/../version.txt"' op-env-v${VERSION}; then
+            echo "ERROR: version baking failed" >&2
+            exit 1
+          fi
+      - name: Upload release asset
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          VERSION=$(cat version.txt)
+          gh release upload "v${VERSION}" "op-env-v${VERSION}" --clobber
+```
+
+**Key detail:** Reuses the same version-baking logic from install.sh. The bake verification check ensures we never publish a binary that still reads version.txt.
+
+### Component 3: Update Mechanism
+
+**What:** An `op-env --update` flag (or standalone `op-env-update` script) that downloads the latest release binary from GitHub.
+
+**Why:** Closes the loop — after a release is published, users can update with a single command instead of cloning and running install.sh.
+
+**How:**
+```bash
+# In bin/op-env, add --update flag handling:
+if [ "$1" = "--update" ]; then
+  LATEST=$(gh release view --repo DAESA24/op-env --json tagName -q .tagName 2>/dev/null)
+  if [ -z "$LATEST" ]; then
+    echo "op-env: could not fetch latest release" >&2
+    exit 1
+  fi
+  ASSET="op-env-${LATEST}"
+  TMPFILE=$(mktemp)
+  gh release download "$LATEST" --repo DAESA24/op-env --pattern "$ASSET" --output "$TMPFILE" --clobber
+  chmod +x "$TMPFILE"
+  mv "$TMPFILE" "${HOME}/.local/bin/op-env"
+  echo "op-env: updated to $LATEST"
+  exit 0
+fi
+```
+
+**Alternative:** Standalone `update.sh` in the repo, keeping op-env itself minimal. This avoids adding `gh` as a runtime dependency of op-env.
+
+**Recommended:** Standalone `update.sh` — simpler, no new dependencies in the main binary.
+
+## Success Criteria for Pattern Reuse
+
+This pattern is ready to apply to other projects when:
+
+1. [ ] op-env has run through at least 2 release cycles with this pipeline
+2. [ ] No manual install.sh runs were needed (all updates via release download)
+3. [ ] The install guard has caught at least one accidental dev install
+4. [ ] CI has caught at least one issue that local testing missed
+5. [ ] The workflow is documented enough that Drew can explain it to another developer
+
+## Implementation Order
+
+1. install.sh guard (smallest change, highest value)
+2. Release workflow binary publishing (enables the update mechanism)
+3. Update mechanism (completes the loop)
+4. Update `pai update` / `ccc` alias chain to use the new update mechanism
+
+Each step should be a separate PR with its own tests.

--- a/install.sh
+++ b/install.sh
@@ -5,17 +5,28 @@
 set -e
 
 INSTALL_DIR="${HOME}/.local/bin"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_REAL=$(readlink "$0" 2>/dev/null || echo "$0")
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_REAL")" && pwd)"
 
 VERSION=$(cat "$SCRIPT_DIR/version.txt" 2>/dev/null || echo "dev")
 
 mkdir -p "$INSTALL_DIR"
+# Remove existing symlink before copy (prevents cp from following dangling symlinks)
+if [ -L "$INSTALL_DIR/op-env" ]; then rm "$INSTALL_DIR/op-env"; fi
 cp "$SCRIPT_DIR/bin/op-env" "$INSTALL_DIR/op-env"
 chmod +x "$INSTALL_DIR/op-env"
 
 # Bake version into installed copy (since version.txt won't be adjacent)
 sed -i.bak "s|cat \"\$SCRIPT_DIR/../version.txt\" 2>/dev/null|echo \"$VERSION\"|" "$INSTALL_DIR/op-env"
 rm -f "$INSTALL_DIR/op-env.bak"
+
+# Verify version was baked correctly — fail loudly if sed pattern didn't match
+# Literal $SCRIPT_DIR match is intentional (not a variable expansion)
+# shellcheck disable=SC2016
+if grep -q 'cat "\$SCRIPT_DIR/../version.txt"' "$INSTALL_DIR/op-env"; then
+  echo "ERROR: version baking failed — installed binary still reads version.txt" >&2
+  exit 1
+fi
 
 echo "Installed op-env $VERSION to $INSTALL_DIR/op-env"
 

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# install.sh test suite — raw bash, no framework dependencies
+# Run: bash test/test-install.sh
+#
+# Tests the installation process in isolated temp directories.
+# Validates dev/prod separation: installed binary must be a standalone
+# copy with baked version, no runtime dependency on the source repo.
+
+set -uo pipefail
+# Note: no set -e — tests intentionally trigger non-zero exits
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALLER="$REPO_DIR/install.sh"
+HELPERS="$SCRIPT_DIR/helpers"
+FIXTURES="$SCRIPT_DIR/fixtures"
+
+# shellcheck source=test/helpers/assert.sh
+source "$HELPERS/assert.sh"
+
+# Read expected version from repo
+EXPECTED_VERSION=$(cat "$REPO_DIR/version.txt" 2>/dev/null || echo "dev")
+
+echo "Running install.sh test suite..."
+echo ""
+
+# ============================================================
+# Helper: run install.sh targeting an isolated temp directory
+# ============================================================
+run_install() {
+  local install_dir="$1"
+  HOME_BACKUP="$HOME"
+  # Override HOME so install.sh writes to our temp dir
+  export HOME="$install_dir"
+  (cd "$REPO_DIR" && bash install.sh 2>&1)
+  local rc=$?
+  export HOME="$HOME_BACKUP"
+  return $rc
+}
+
+# ============================================================
+# Category 1: Unit Tests — File Type and Structure
+# ============================================================
+
+echo "--- Unit: File type and structure ---"
+
+# Test 1: Creates regular file (not symlink)
+TMPDIR1=$(mktemp -d)
+run_install "$TMPDIR1" > /dev/null
+result="regular"
+[ -L "$TMPDIR1/.local/bin/op-env" ] && result="symlink"
+[ -f "$TMPDIR1/.local/bin/op-env" ] || result="missing"
+assert_eq "regular" "$result" "install creates regular file, not symlink"
+rm -rf "$TMPDIR1"
+
+# Test 2: Overwrites existing symlink with regular file
+TMPDIR2=$(mktemp -d)
+mkdir -p "$TMPDIR2/.local/bin"
+ln -s /nonexistent/path "$TMPDIR2/.local/bin/op-env"
+run_install "$TMPDIR2" > /dev/null
+result="regular"
+[ -L "$TMPDIR2/.local/bin/op-env" ] && result="symlink"
+[ -f "$TMPDIR2/.local/bin/op-env" ] || result="missing"
+assert_eq "regular" "$result" "install overwrites symlink with regular file"
+rm -rf "$TMPDIR2"
+
+# Test 3: Overwrites existing regular file (upgrade path)
+TMPDIR3=$(mktemp -d)
+mkdir -p "$TMPDIR3/.local/bin"
+echo "old version" > "$TMPDIR3/.local/bin/op-env"
+run_install "$TMPDIR3" > /dev/null
+result=$(head -1 "$TMPDIR3/.local/bin/op-env")
+assert_eq "#!/bin/bash" "$result" "install overwrites existing file on upgrade"
+rm -rf "$TMPDIR3"
+
+# Test 4: Installed binary has executable permissions
+TMPDIR4=$(mktemp -d)
+run_install "$TMPDIR4" > /dev/null
+result="not-executable"
+[ -x "$TMPDIR4/.local/bin/op-env" ] && result="executable"
+assert_eq "executable" "$result" "installed binary is executable"
+rm -rf "$TMPDIR4"
+
+# ============================================================
+# Category 2: Unit Tests — Version Baking
+# ============================================================
+
+echo "--- Unit: Version baking ---"
+
+# Test 5: Version is baked into installed copy
+TMPDIR5=$(mktemp -d)
+run_install "$TMPDIR5" > /dev/null
+result=$(grep -c "echo \"$EXPECTED_VERSION\"" "$TMPDIR5/.local/bin/op-env" || true)
+assert_eq "1" "$result" "version baked into installed copy"
+rm -rf "$TMPDIR5"
+
+# Test 6: Installed binary does NOT contain version.txt read pattern
+TMPDIR6=$(mktemp -d)
+run_install "$TMPDIR6" > /dev/null
+result=$(grep -c 'cat "\$SCRIPT_DIR/../version.txt"' "$TMPDIR6/.local/bin/op-env" || true)
+assert_eq "0" "$result" "installed binary has no version.txt dependency"
+rm -rf "$TMPDIR6"
+
+# ============================================================
+# Category 3: Unit Tests — Directory and Path Handling
+# ============================================================
+
+echo "--- Unit: Directory and path handling ---"
+
+# Test 7: Creates target directory if missing
+TMPDIR7=$(mktemp -d)
+# Ensure .local/bin does NOT exist
+rm -rf "$TMPDIR7/.local"
+run_install "$TMPDIR7" > /dev/null
+result="missing"
+[ -f "$TMPDIR7/.local/bin/op-env" ] && result="created"
+assert_eq "created" "$result" "install creates directory if missing"
+rm -rf "$TMPDIR7"
+
+# Test 8: Works from any working directory
+TMPDIR8=$(mktemp -d)
+HOME_BACKUP="$HOME"
+export HOME="$TMPDIR8"
+(cd /tmp && bash "$INSTALLER" 2>&1) > /dev/null
+rc=$?
+export HOME="$HOME_BACKUP"
+result="fail"
+[ $rc -eq 0 ] && [ -f "$TMPDIR8/.local/bin/op-env" ] && result="pass"
+assert_eq "pass" "$result" "install works from any working directory"
+rm -rf "$TMPDIR8"
+
+# ============================================================
+# Category 4: Functional Tests — Installed Binary Behavior
+# ============================================================
+
+echo "--- Functional: Installed binary behavior ---"
+
+# Put mock op in PATH for functional tests
+export PATH="$HELPERS:$PATH"
+chmod +x "$HELPERS/op"
+
+# Test 9: Installed op-env --version outputs correct version
+TMPDIR9=$(mktemp -d)
+run_install "$TMPDIR9" > /dev/null
+result=$("$TMPDIR9/.local/bin/op-env" --version 2>&1)
+assert_eq "op-env $EXPECTED_VERSION" "$result" "installed --version shows correct version"
+rm -rf "$TMPDIR9"
+
+# Test 10: Installed op-env --help exits 0 with usage text
+TMPDIR10=$(mktemp -d)
+run_install "$TMPDIR10" > /dev/null
+result=$("$TMPDIR10/.local/bin/op-env" --help 2>&1)
+rc=$?
+assert_eq "0" "$rc" "installed --help exits 0"
+assert_contains "$result" "USAGE:" "installed --help contains usage text"
+rm -rf "$TMPDIR10"
+
+# Test 11: Installed op-env with mock op resolves template keys
+TMPDIR11=$(mktemp -d)
+run_install "$TMPDIR11" > /dev/null
+result=$("$TMPDIR11/.local/bin/op-env" --tpl "$FIXTURES/test.tpl" --check 2>&1)
+assert_contains "$result" "TEST_KEY_A" "installed binary resolves template keys"
+rm -rf "$TMPDIR11"
+
+# Test 12: Installed op-env fails gracefully when op not found
+TMPDIR12=$(mktemp -d)
+run_install "$TMPDIR12" > /dev/null
+# Run with PATH stripped of mock op to simulate op missing
+# Capture exit code without || true swallowing it
+PATH="/usr/bin:/bin" "$TMPDIR12/.local/bin/op-env" --tpl "$FIXTURES/test.tpl" echo hello > /dev/null 2>&1
+rc=$?
+# op-env requires op — it should fail (exit non-zero), not succeed silently
+pass="no"
+[ $rc -ne 0 ] && pass="yes"
+assert_eq "yes" "$pass" "installed binary fails when op not available"
+rm -rf "$TMPDIR12"
+
+# Test 13: exec "$@" is last non-comment line in installed binary
+TMPDIR13=$(mktemp -d)
+run_install "$TMPDIR13" > /dev/null
+last_line=$(grep -v '^\s*#' "$TMPDIR13/.local/bin/op-env" | grep -v '^\s*$' | tail -1)
+result="no"
+echo "$last_line" | grep -q 'exec "\$@"' && result="yes"
+assert_eq "yes" "$result" "installed binary ends with exec (TTY preserved)"
+rm -rf "$TMPDIR13"
+
+# ============================================================
+report


### PR DESCRIPTION
## Summary

Hardens install.sh for clean dev/prod separation and adds comprehensive installation testing.

**Problem:** Production binary at `~/.local/bin/op-env` was a symlink pointing into the dev working tree. Renaming the dev directory broke all Claude Code aliases.

**Root cause:** The symlink was created manually, bypassing install.sh (which correctly uses `cp`). Nothing tested or enforced that install.sh produces a standalone binary.

**Fix:** Three layers of hardening + testing + CI coverage.

## Changes

### install.sh Hardening
- Symlink detection and removal before `cp` (prevents dangling symlink failures)
- Readlink-safety for path resolution (macOS-compatible, matches bin/op-env pattern)
- Version bake verification — fails loudly if sed pattern doesn't match

### Installation Test Suite (`test/test-install.sh`)
- 14 TDD tests using same `assert.sh` helper as existing suite
- 8 unit tests: file type, symlink overwrite, upgrade, permissions, version baking, directory creation, working directory independence
- 5 functional tests: `--version`, `--help`, template resolution with mock op, graceful failure without op, TTY preservation

### CI/CD Expansion (`pr-check.yml`)
- New "Installation tests" step runs `test/test-install.sh` on every PR
- B3 shellcheck scope expanded from `bin/*` to `bin/* install.sh`
- B1 exfiltration scope expanded from `bin/*` to `bin/* install.sh`

### Plans
- `Plans/dev-prod-separation-2026-03-27.md` — documents the hardening rationale
- `Plans/release-first-pipeline-2026-03-27.md` — future release-first enforcement pattern

## Review Checklist
- [x] R1: Fail-closed — all error paths exit before `exec "$@"`
- [x] R2: Backwards compatible — existing install.sh usage unchanged
- [x] R3: Proportionate — complexity justified by symlink failure incident
- [x] R4: No chezmoi conflict