### PR TITLE
fix(auth): store GitHub PAT in Keychain via gh auth login at session start

### DIFF
--- a/Plans/fix-gh-pat-prompts-2026-03-27.md
+++ b/Plans/fix-gh-pat-prompts-2026-03-27.md
@@ -1,0 +1,122 @@
+---
+title: Fix GitHub CLI PAT Repeated Authorization Prompts
+status: planned
+created: 2026-03-27
+author: Daesa (PAI)
+priority: high
+scope: op-env gh CLI integration, .zshrc alias management
+github-issue: https://github.com/DAESA24/op-env/issues/25
+---
+
+# Fix GitHub CLI PAT Repeated Authorization Prompts
+
+## Problem
+
+During Claude Code sessions, every `gh` CLI command triggers a 1Password authorization prompt. This happens because:
+
+1. `.zshrc` sources `~/.config/op/plugins.sh` which sets `alias gh="op plugin run -- gh"`
+2. The 1Password plugin resolves the GitHub PAT from 1Password on EVERY invocation
+3. Each resolution triggers a biometric/authorization prompt
+
+The existing mitigation (`.zshrc` line 14: `[[ -n "$GITHUB_TOKEN" ]] && unalias gh`) fails because:
+- **In non-op-env sessions:** GITHUB_TOKEN is never set, so the alias persists
+- **In op-env sessions:** Evidence shows GITHUB_TOKEN does not propagate into Claude Code's Bash tool environment (possibly sandboxed), so the alias persists there too
+
+## Root Cause (First Principles)
+
+The current design fights the 1Password plugin system. The alias wraps every `gh` call through `op plugin run`, and the only defense is removing the alias — which depends on a fragile chain of env var propagation and shell sourcing order.
+
+**Key insight:** gh CLI has its own secure credential store (macOS Keychain). Instead of fighting the alias, we should feed gh its token through gh's native auth mechanism at session start. This makes the alias irrelevant.
+
+## Recommended Fix: Option A — `gh auth login` at Session Start
+
+### How It Works
+
+Add a post-resolution step to op-env that runs `gh auth login --with-token` after resolving secrets. This stores the PAT in gh's native credential store (macOS Keychain).
+
+```bash
+# In op-env, after secret resolution and before exec:
+if [ -n "$GITHUB_TOKEN" ]; then
+  echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null
+fi
+```
+
+### Why This Works
+
+1. **No alias dependency:** gh uses Keychain auth regardless of whether the alias is present
+2. **No env propagation dependency:** The token is in Keychain, not in env vars
+3. **Session-fresh:** Each op-env session refreshes the Keychain token from 1Password
+4. **Secure:** macOS Keychain is encrypted, not plaintext
+5. **Works everywhere:** All processes on the system can use `gh` without prompts after session start
+
+### Changes Required
+
+**op-env (`bin/op-env`):**
+- Add `gh auth login --with-token` step after secret resolution, before `exec`
+- Gate behind `GITHUB_TOKEN` being resolved (skip if not in template)
+- Silent failure (don't abort if gh isn't installed)
+
+**.zshrc:**
+- Remove the fragile unalias logic (lines 12-14)
+- Optionally remove `source plugins.sh` entirely if gh is the only 1Password plugin
+- OR: keep plugins.sh but the gh plugin becomes harmless (Keychain auth takes precedence)
+
+**Tests (`test/test-op-env.sh`):**
+- Add test: op-env calls `gh auth login` when GITHUB_TOKEN is resolved
+- Add test: op-env skips `gh auth login` when GITHUB_TOKEN is not in template
+- Add test: op-env doesn't fail if `gh` binary is missing
+
+### Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| gh not installed | Silent skip — `gh auth login` fails, op-env continues |
+| No GITHUB_TOKEN in template | Skip — only runs when GITHUB_TOKEN is resolved |
+| Multiple concurrent sessions | Safe — Keychain handles concurrent writes |
+| PAT rotated in 1Password | Refreshed on next session start (op-env re-resolves) |
+| Non-op-env gh usage | Falls back to Keychain auth (from last op-env session) or plugin |
+
+## Alternative Options (Considered, Not Recommended)
+
+### Option B: Remove 1Password gh Plugin Entirely
+- **Pro:** Simplest possible fix — no alias, no conflict
+- **Con:** Breaks `gh` usage outside op-env sessions (no auth at all unless manually configured)
+- **Verdict:** Too aggressive — Drew may want to use `gh` outside Claude Code
+
+### Option C: Fix Env Var Propagation
+- **Pro:** Makes the current design work as intended
+- **Con:** Claude Code's Bash tool env behavior may be intentional/unfixable from our side
+- **Con:** Even if fixed, the alias/unalias dance remains fragile
+- **Verdict:** Treating symptoms, not the root cause
+
+### Option D: Replace Alias with Function
+- **Pro:** Functions take precedence over aliases and can check env vars dynamically
+- **Con:** Still depends on GITHUB_TOKEN being in env (same propagation problem)
+- **Verdict:** Slightly better than current, but same fundamental fragility
+
+## Test Strategy
+
+### Unit Tests (in test-op-env.sh)
+1. When GITHUB_TOKEN is resolved, `gh auth login --with-token` is called
+2. When GITHUB_TOKEN is NOT resolved, `gh auth login` is not called
+3. When `gh` binary is missing, op-env doesn't fail
+4. The `gh auth login` call happens BEFORE `exec "$@"` (not after)
+
+### Functional Tests (manual)
+1. Start session via `ccc` → run `gh auth status` → should show PAT in keyring (not just env)
+2. Run `gh pr list` → no 1Password prompt
+3. Run `gh issue create` → no 1Password prompt
+4. Outside op-env: run `gh auth status` → keyring auth still available from last session
+
+### CI Tests
+- Mock `gh` binary in test helpers (like mock `op`)
+- Verify the `gh auth login` call receives the correct token on stdin
+
+## Implementation Order
+
+1. Add mock `gh` to test helpers
+2. Write tests for `gh auth login` integration
+3. Modify `bin/op-env` to call `gh auth login --with-token` after resolution
+4. Update `.zshrc` to remove fragile unalias logic
+5. Run through CI via PR
+6. Manual functional testing after merge

--- a/Plans/release-first-pipeline-2026-03-27.md
+++ b/Plans/release-first-pipeline-2026-03-27.md
@@ -7,7 +7,7 @@ priority: high
 scope: install.sh guard, release workflow artifact publishing, update mechanism
 depends-on: feat/install-hardening PR merge
 pattern-test: op-env (first project to test this pattern)
-github-issue: TBD (will be linked after creation)
+github-issue: https://github.com/DAESA24/op-env/issues/24
 ---
 
 # Release-First Pipeline Pattern

--- a/bin/op-env
+++ b/bin/op-env
@@ -156,4 +156,11 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   fi
 fi
 
+# Store GITHUB_TOKEN in gh CLI's native credential store (macOS Keychain)
+# so gh works without repeated 1Password prompts, even when the
+# 1Password plugin alias is active. Silent failure if gh isn't installed.
+if [ -n "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
+  echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null || true
+fi
+
 exec "$@"

--- a/test/helpers/gh
+++ b/test/helpers/gh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Mock gh CLI — captures auth login --with-token calls for testing
+# Set MOCK_GH_LOG to a file path to record calls.
+# Set MOCK_GH_FAIL=1 to simulate gh failure.
+
+LOG="${MOCK_GH_LOG:-/dev/null}"
+
+if [ "${MOCK_GH_FAIL:-0}" = "1" ]; then
+  exit 1
+fi
+
+# Record the full command
+echo "gh $*" >> "$LOG"
+
+# Handle auth login --with-token: read token from stdin
+if [ "$1" = "auth" ] && [ "$2" = "login" ] && [ "$3" = "--with-token" ]; then
+  TOKEN=$(cat)
+  echo "TOKEN=$TOKEN" >> "$LOG"
+  exit 0
+fi
+
+# Default: success
+exit 0

--- a/test/test-op-env.sh
+++ b/test/test-op-env.sh
@@ -322,6 +322,56 @@ assert_contains "$(cat "$existing_hook")" "op-env-scan" "Install hook adds scann
 rm -rf "$HOOK_TMPDIR2"
 
 # ============================================================
+# Category 9: gh CLI Auth Integration
+# ============================================================
+
+echo "--- gh CLI Auth Integration ---"
+
+chmod +x "$HELPERS/gh"
+
+# gh auth login NOT called when no GITHUB_TOKEN in template
+GH_LOG=$(mktemp)
+export MOCK_GH_LOG="$GH_LOG"
+result=$("$OP_ENV" --tpl "$FIXTURES/test.tpl" -q echo done 2>&1)
+gh_called="0"
+[ -s "$GH_LOG" ] && gh_called=$(grep -c "gh auth login --with-token" "$GH_LOG" || true)
+assert_eq "0" "$gh_called" "gh auth login not called when no GITHUB_TOKEN key"
+rm -f "$GH_LOG"
+
+# gh auth login called when GITHUB_TOKEN resolved
+GH_TPL=$(mktemp)
+echo "GITHUB_TOKEN=op://vault/item/token" > "$GH_TPL"
+GH_LOG2=$(mktemp)
+export MOCK_GH_LOG="$GH_LOG2"
+result=$("$OP_ENV" --tpl "$GH_TPL" -q echo done 2>&1)
+gh_called="0"
+[ -s "$GH_LOG2" ] && gh_called=$(grep -c "gh auth login --with-token" "$GH_LOG2" || true)
+assert_eq "1" "$gh_called" "gh auth login called when GITHUB_TOKEN resolved"
+rm -f "$GH_LOG2" "$GH_TPL"
+
+# gh auth login receives the correct token value
+GH_TPL2=$(mktemp)
+echo "GITHUB_TOKEN=op://vault/item/token" > "$GH_TPL2"
+GH_LOG3=$(mktemp)
+export MOCK_GH_LOG="$GH_LOG3"
+result=$("$OP_ENV" --tpl "$GH_TPL2" -q echo done 2>&1)
+token_value=$(grep "^TOKEN=" "$GH_LOG3" 2>/dev/null | cut -d= -f2-)
+assert_eq "mock_GITHUB_TOKEN_value_12345678" "$token_value" "gh auth login receives correct token"
+rm -f "$GH_LOG3" "$GH_TPL2"
+unset MOCK_GH_LOG
+
+# op-env works when gh binary not available
+GH_TPL3=$(mktemp)
+echo "GITHUB_TOKEN=op://vault/item/token" > "$GH_TPL3"
+# Temporarily hide the mock gh by renaming it
+mv "$HELPERS/gh" "$HELPERS/gh.bak"
+result=$("$OP_ENV" --tpl "$GH_TPL3" -q echo done 2>&1)
+rc=$?
+mv "$HELPERS/gh.bak" "$HELPERS/gh"
+assert_eq "0" "$rc" "op-env succeeds when gh not available"
+rm -f "$GH_TPL3"
+
+# ============================================================
 # Results
 # ============================================================
 


### PR DESCRIPTION
## Summary

Fixes #25 — eliminates repeated 1Password authorization prompts during Claude Code sessions.

**Root cause:** The 1Password plugin alias (`alias gh="op plugin run -- gh"` from `plugins.sh`) intercepts every `gh` call and triggers a biometric prompt each time. The previous mitigation (`unalias gh` when GITHUB_TOKEN is set) doesn't work because GITHUB_TOKEN doesn't propagate into Claude Code's Bash tool environment.

**Fix:** After op-env resolves GITHUB_TOKEN from 1Password, pipe it into `gh auth login --with-token`. This stores the PAT in macOS Keychain — gh's native credential store. The 1Password plugin alias becomes irrelevant because gh authenticates from Keychain.

## Changes

| File | Change |
|------|--------|
| `bin/op-env` | Add `gh auth login --with-token` after secret resolution, before `exec` |
| `test/helpers/gh` | Mock gh CLI that captures auth login calls and token values |
| `test/test-op-env.sh` | 4 new tests for gh auth integration |
| `Plans/fix-gh-pat-prompts-2026-03-27.md` | Root cause analysis and implementation plan |
| `Plans/release-first-pipeline-2026-03-27.md` | Link github issue (minor update) |

## Safety

- Silent failure if `gh` isn't installed (`command -v gh` check + `|| true`)
- Only runs when GITHUB_TOKEN is actually resolved (not for other secrets)
- `exec "$@"` remains the last line (B2 TTY preservation intact)
- 1Password remains the source of truth — Keychain copy refreshed each session

## Review Checklist
- [x] R1: Fail-closed — all error paths exit before `exec "$@"`
- [x] R2: Backwards compatible — existing op-env usage unchanged
- [x] R3: Proportionate — 5-line fix for a significant UX problem
- [x] R4: No chezmoi conflict

## Testing

- 60/60 op-env tests pass (56 existing + 4 new)
- 14/14 installation tests pass
- Shellcheck clean on bin/op-env