### PR TITLE
fix(auth): export GH_TOKEN to bypass 1Password plugin biometric prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+# op-env-dev
+See [README.md](README.md) for documentation and conventions.

--- a/Plans/dev-prod-separation-2026-03-27.md
+++ b/Plans/dev-prod-separation-2026-03-27.md
@@ -12,7 +12,7 @@ related-issue: broken symlink at ~/.local/bin/op-env after dev directory rename
 
 ## Context
 
-Drew's `op-env` production binary at `~/.local/bin/op-env` is a broken symlink pointing to the old dev directory path (`~/projects/dev-tools/op-env/bin/op-env`). The directory was renamed to `op-env-dev`. The `install.sh` script correctly uses `cp` (not symlink), but the symlink was likely created manually at some point, bypassing install.sh.
+Drew's `op-env` production binary at `~/.local/bin/op-env` was a broken symlink pointing to the old dev directory path (`~/projects/dev-tools/op-env/bin/op-env`). The directory was renamed to `op-env-dev` and later relocated to `~/projects/dev/dev-tools/infra-dev/op-env-dev/`. The `install.sh` script correctly uses `cp` (not symlink), but the symlink was likely created manually at some point, bypassing install.sh. PR #23 fixed this — the production binary is now a standalone copy.
 
 **Goal:** The dev directory is purely for development. The production binary is an independent copy deployed by running `install.sh` after releases. CI/CD validates that the installation process works correctly. No future directory rename or dev-side change should ever break the production binary.
 

--- a/Plans/release-first-pipeline-2026-03-27.md
+++ b/Plans/release-first-pipeline-2026-03-27.md
@@ -18,7 +18,7 @@ On 2026-03-27, a broken symlink at `~/.local/bin/op-env` caused all Claude Code 
 
 **Lesson:** Production binaries should never depend on the dev working tree. They should come exclusively from releases.
 
-**This pattern is being tested with op-env first.** If it works well, it can be applied to other projects in `~/projects/dev-tools/`.
+**This pattern is being tested with op-env first.** If it works well, it can be applied to other projects in `~/projects/dev/dev-tools/`.
 
 ## Current State (after install-hardening PR)
 

--- a/bin/op-env
+++ b/bin/op-env
@@ -156,11 +156,17 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   fi
 fi
 
-# Store GITHUB_TOKEN in gh CLI's native credential store (macOS Keychain)
-# so gh works without repeated 1Password prompts, even when the
-# 1Password plugin alias is active. Silent failure if gh isn't installed.
-if [ -n "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
-  echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null || true
+# Prevent 1Password shell plugin from prompting for gh commands.
+# The plugin (alias gh="op plugin run -- gh") checks whether GH_TOKEN is
+# already set in the environment and skips the vault lookup / biometric
+# prompt when it is.  We also store the token in gh's credential store
+# via `command gh` (bypasses the alias) as a fallback for contexts where
+# env vars aren't inherited.
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  export GH_TOKEN="$GITHUB_TOKEN"
+  if command -v gh >/dev/null 2>&1; then
+    echo "$GITHUB_TOKEN" | command gh auth login --with-token 2>/dev/null || true
+  fi
 fi
 
 exec "$@"

--- a/test/test-op-env.sh
+++ b/test/test-op-env.sh
@@ -371,6 +371,24 @@ mv "$HELPERS/gh.bak" "$HELPERS/gh"
 assert_eq "0" "$rc" "op-env succeeds when gh not available"
 rm -f "$GH_TPL3"
 
+# GH_TOKEN exported alongside GITHUB_TOKEN (prevents 1Password plugin prompts)
+GH_TPL4=$(mktemp)
+echo "GITHUB_TOKEN=op://vault/item/token" > "$GH_TPL4"
+result=$("$OP_ENV" --tpl "$GH_TPL4" -q "$HELPERS/check-env.sh" GH_TOKEN GITHUB_TOKEN 2>&1)
+gh_token_val=$(echo "$result" | grep "^GH_TOKEN=" | cut -d= -f2-)
+github_token_val=$(echo "$result" | grep "^GITHUB_TOKEN=" | cut -d= -f2-)
+assert_eq "$github_token_val" "$gh_token_val" "GH_TOKEN exported equal to GITHUB_TOKEN"
+assert_eq "mock_GITHUB_TOKEN_value_12345678" "$gh_token_val" "GH_TOKEN has correct resolved value"
+rm -f "$GH_TPL4"
+
+# GH_TOKEN not set when GITHUB_TOKEN not in template
+GH_TPL5=$(mktemp)
+echo "SOME_OTHER_KEY=op://vault/item/key" > "$GH_TPL5"
+result=$("$OP_ENV" --tpl "$GH_TPL5" -q "$HELPERS/check-env.sh" GH_TOKEN 2>&1)
+gh_token_val=$(echo "$result" | grep "^GH_TOKEN=" | cut -d= -f2-)
+assert_eq "UNSET" "$gh_token_val" "GH_TOKEN not set when GITHUB_TOKEN absent from template"
+rm -f "$GH_TPL5"
+
 # ============================================================
 # Results
 # ============================================================


### PR DESCRIPTION
## Summary

Fixes #29 — GitHub CLI PAT authorization fix not working.

The 1Password shell plugin (`alias gh="op plugin run -- gh"`) intercepts every `gh` command and triggers a biometric prompt to resolve credentials from the vault. The previous fix (`gh auth login --with-token`) stored the PAT in gh's credential store, but the plugin prompts **before** gh checks its config.

## Changes

**`bin/op-env`:**
- Export `GH_TOKEN=$GITHUB_TOKEN` so the 1Password plugin sees the credential already available and skips the vault lookup / biometric prompt
- Use `command gh` to bypass the `op plugin run -- gh` alias when running `gh auth login --with-token`

**`test/test-op-env.sh`:**
- Verify `GH_TOKEN` is exported with correct value when `GITHUB_TOKEN` is in template
- Verify `GH_TOKEN` is not set when `GITHUB_TOKEN` is absent from template

## Review checklist

- [x] R1: Fail-closed — every error path exits before `exec`
- [x] R2: Backwards compatible — existing usage unchanged
- [x] R3: Proportionate — minimal change for the fix
- [x] R4: No chezmoi conflict

Co-Authored-By: Claude <noreply@anthropic.com>