### PR TITLE
feat: update mechanism via standalone update.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,12 @@ if grep -q 'cat "\$SCRIPT_DIR/../version.txt"' "$INSTALL_DIR/op-env"; then
   exit 1
 fi
 
+# Install update script alongside op-env
+if [ -f "$SCRIPT_DIR/update.sh" ]; then
+  cp "$SCRIPT_DIR/update.sh" "$INSTALL_DIR/op-env-update"
+  chmod +x "$INSTALL_DIR/op-env-update"
+fi
+
 echo "Installed op-env $VERSION to $INSTALL_DIR/op-env"
 
 # Check if ~/.local/bin is in PATH

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -210,4 +210,26 @@ assert_eq "installed" "$result" "guard accepts --dev flag on untagged commit"
 rm -rf "$TMPDIR15"
 
 # ============================================================
+# Category 6: Update Script Installation
+# ============================================================
+
+echo "--- Update script installation ---"
+
+# Test 16: install.sh copies update.sh as op-env-update
+TMPDIR16=$(mktemp -d)
+run_install "$TMPDIR16" > /dev/null
+result="missing"
+[ -f "$TMPDIR16/.local/bin/op-env-update" ] && result="installed"
+assert_eq "installed" "$result" "install copies update.sh as op-env-update"
+rm -rf "$TMPDIR16"
+
+# Test 17: op-env-update has executable permissions
+TMPDIR17=$(mktemp -d)
+run_install "$TMPDIR17" > /dev/null
+result="not-executable"
+[ -x "$TMPDIR17/.local/bin/op-env-update" ] && result="executable"
+assert_eq "executable" "$result" "op-env-update is executable"
+rm -rf "$TMPDIR17"
+
+# ============================================================
 report

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# update.sh — Download latest op-env release binary from GitHub
+# Installed to ~/.local/bin/op-env-update by install.sh
+# Usage: op-env-update
+set -euo pipefail
+
+REPO="DAESA24/op-env"
+INSTALL_DIR="${HOME}/.local/bin"
+CURRENT_BIN="${INSTALL_DIR}/op-env"
+
+# Require gh CLI
+if ! command -v gh >/dev/null 2>&1; then
+  echo "op-env-update: gh CLI is required but not found" >&2
+  echo "  Install: https://cli.github.com/" >&2
+  exit 1
+fi
+
+# Fetch latest release tag
+LATEST=$(gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null) || true
+if [ -z "$LATEST" ]; then
+  echo "op-env-update: could not fetch latest release from $REPO" >&2
+  exit 1
+fi
+
+# Check current version (skip download if already up to date)
+if [ -x "$CURRENT_BIN" ]; then
+  CURRENT=$("$CURRENT_BIN" --version 2>&1 | awk '{print $2}')
+  LATEST_NORM="${LATEST#v}"
+  if [ "$CURRENT" = "$LATEST_NORM" ]; then
+    echo "op-env: already at $LATEST_NORM (up to date)"
+    exit 0
+  fi
+  echo "op-env: updating $CURRENT -> $LATEST_NORM"
+else
+  echo "op-env: installing $LATEST"
+fi
+
+# Asset name must match what the release workflow publishes
+ASSET="op-env"
+
+# Atomic download: tmpfile + mv (never leaves a half-written binary)
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+if ! gh release download "$LATEST" --repo "$REPO" --pattern "$ASSET" --output "$TMPFILE" --clobber; then
+  echo "op-env-update: failed to download $ASSET from release $LATEST" >&2
+  exit 1
+fi
+
+chmod +x "$TMPFILE"
+mkdir -p "$INSTALL_DIR"
+
+# Verify the downloaded binary is functional
+if ! "$TMPFILE" --version >/dev/null 2>&1; then
+  echo "op-env-update: downloaded binary failed --version check" >&2
+  exit 1
+fi
+
+mv "$TMPFILE" "$CURRENT_BIN"
+trap - EXIT
+
+NEW_VER=$("$CURRENT_BIN" --version 2>&1 | awk '{print $2}')
+echo "op-env: updated to $NEW_VER"


### PR DESCRIPTION
## Summary

Standalone `update.sh` script that downloads the latest release binary from GitHub, replacing the manual `git pull && ./install.sh` workflow. Installed to PATH as `op-env-update` so users can update without the repo.

Part of #24 (Component 3 of 3).

## Motivation

With Component 1 (install.sh guard, PR #32) merged and Component 2 (release binary publishing, PR #35) in progress, the final piece is giving users a one-command update path. Currently updating requires: clone/pull the repo, checkout the tag, run install.sh. The update mechanism reduces this to `op-env-update` from anywhere.

## Design Decision: Standalone Script, Installed to PATH

**Recommendation: `update.sh` at repo root, installed to `~/.local/bin/op-env-update` by install.sh.**

### Why standalone (not `--update` flag in bin/op-env)

1. **F2 compliance** — `gh` is not on the F2 allowlist. Keeping it out of `bin/` avoids triggering F2 on every review.
2. **B2 compliance** — No modification to `bin/op-env`, so `exec "$@"` is untouched.
3. **Separation of concerns** — `bin/op-env` does secret injection. Updating is lifecycle, not runtime.
4. **No runtime dependency** — `op-env` runs every shell session; `gh` is only needed during updates.

### Why installed to PATH (not repo-only)

The founding principle of #24 is: **production should not depend on the dev working tree.** A repo-only update script contradicts this — users would need the repo to update, which is exactly the coupling #24 eliminates.

First principles analysis:
- `update.sh` is entirely self-contained — it needs `gh`, network, and the hardcoded repo name. Zero repo file dependencies.
- `install.sh` is inherently repo-bound (copies repo files). `update.sh` is inherently repo-independent (downloads from GitHub). They have opposite dependency profiles.
- Placing `update.sh` at repo root was reasoning by analogy with `install.sh`, not from the actual dependency structure.

Cost of installing to PATH: ~3 lines in `install.sh`, one extra asset in the release workflow.

## Design

### `update.sh` (repo root, installed to `~/.local/bin/op-env-update`)

```bash
#!/bin/bash
# update.sh — Download latest op-env release binary from GitHub
# Installed to ~/.local/bin/op-env-update by install.sh
# Usage: op-env-update
set -euo pipefail

REPO="DAESA24/op-env"
INSTALL_DIR="${HOME}/.local/bin"
CURRENT_BIN="${INSTALL_DIR}/op-env"

# Require gh CLI
if ! command -v gh >/dev/null 2>&1; then
  echo "op-env-update: gh CLI is required but not found" >&2
  echo "  Install: https://cli.github.com/" >&2
  exit 1
fi

# Fetch latest release tag
LATEST=$(gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null) || true
if [ -z "$LATEST" ]; then
  echo "op-env-update: could not fetch latest release from $REPO" >&2
  exit 1
fi

# Check current version (skip download if already up to date)
if [ -x "$CURRENT_BIN" ]; then
  CURRENT=$("$CURRENT_BIN" --version 2>&1 | awk '{print $2}')
  LATEST_NORM="${LATEST#v}"
  if [ "$CURRENT" = "$LATEST_NORM" ]; then
    echo "op-env: already at $LATEST_NORM (up to date)"
    exit 0
  fi
  echo "op-env: updating $CURRENT -> $LATEST_NORM"
else
  echo "op-env: installing $LATEST"
fi

# Asset name must match what Component 2 publishes
ASSET="op-env"

# Atomic download: tmpfile + mv (never leaves a half-written binary)
TMPFILE=$(mktemp)
trap 'rm -f "$TMPFILE"' EXIT

if ! gh release download "$LATEST" --repo "$REPO" --pattern "$ASSET" --output "$TMPFILE" --clobber; then
  echo "op-env-update: failed to download $ASSET from release $LATEST" >&2
  exit 1
fi

chmod +x "$TMPFILE"
mkdir -p "$INSTALL_DIR"

# Verify the downloaded binary is functional
if ! "$TMPFILE" --version >/dev/null 2>&1; then
  echo "op-env-update: downloaded binary failed --version check" >&2
  exit 1
fi

mv "$TMPFILE" "$CURRENT_BIN"
trap - EXIT

NEW_VER=$("$CURRENT_BIN" --version 2>&1 | awk '{print $2}')
echo "op-env: updated to $NEW_VER"
```

### install.sh addition (~3 lines)

```bash
# Install update script alongside op-env
if [ -f "$SCRIPT_DIR/update.sh" ]; then
  cp "$SCRIPT_DIR/update.sh" "$INSTALL_DIR/op-env-update"
  chmod +x "$INSTALL_DIR/op-env-update"
fi
```

### Release workflow addition (Component 2 PR #35)

Add `op-env-update` as a second release asset so fresh installs from releases also get the updater:

```yaml
- name: Upload release assets
  run: |
    TAG="${{ needs.release-please.outputs.tag_name }}"
    gh release upload "$TAG" op-env --clobber
    gh release upload "$TAG" update.sh#op-env-update --clobber
```

Note: This change belongs in PR #35, not this PR. Flagged here for coordination.

## Key Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Standalone vs flag | `update.sh` standalone | F2, B2, separation of concerns |
| Installed to PATH | Yes, as `op-env-update` | #24 principle: no dev repo dependency for production |
| Asset name for op-env | `op-env` (plain) | Matches Component 2 contract |
| Version check | Compare before download | Idempotent, avoids unnecessary downloads |
| Download verification | Run `--version` on tmpfile | Catches corrupt/wrong asset before replacing |
| Source location | Repo root | Lifecycle script, like install.sh |
| Installed name | `op-env-update` | Namespaced, discoverable, avoids collision |
| Error handling | `set -euo pipefail` + explicit checks | Fail-closed on every error path |
| Version output | `2>&1` capture | `op-env --version` outputs to stderr |

## Edge Cases

| Scenario | Behavior |
|----------|----------|
| No releases exist | `gh release view` fails -> "could not fetch latest release" -> exit 1 |
| Network failure mid-download | `gh release download` fails -> exit 1, existing binary untouched |
| `gh` CLI not installed | Detected upfront -> clear error with install link -> exit 1 |
| Already at latest version | Version comparison -> "already up to date" -> exit 0 |
| Component 2 not yet merged (no asset) | `gh release download` fails on missing pattern -> exit 1 |
| `~/.local/bin` does not exist | `mkdir -p` creates it |
| Downloaded binary is corrupt | `--version` check fails -> exit 1, existing binary untouched |
| op-env not yet installed (fresh) | Skips version comparison, proceeds to download |
| update.sh not present in repo (release-only install) | `install.sh` guards with `if [ -f ]`, skips gracefully |

## Test Strategy

**Cannot be fully tested until Component 2 is merged and a release is cut** (runtime dependency).

### Immediate validation
- `shellcheck update.sh` passes
- install.sh copies update.sh to `~/.local/bin/op-env-update` correctly
- `op-env-update` without network/gh shows correct error messages

### Post-Component 2 validation
1. Run `op-env-update` — should download and install latest release
2. Run `op-env-update` again — should report "already up to date"
3. Manually downgrade, run `op-env-update` — should detect mismatch and update
4. Disconnect network — should fail cleanly
5. Verify `op-env --version` matches release tag after update
6. Verify `op-env <command>` still works (TTY preservation intact)

## Files Changed

| File | Change |
|------|--------|
| `update.sh` | New file — standalone update script (~50 lines) |
| `install.sh` | Add ~3 lines to copy update.sh to PATH as op-env-update |
| `test/test-install.sh` | Add test: op-env-update is installed alongside op-env |

## Cross-PR Coordination

- **Asset name contract with PR #35**: Both agree on `op-env` as the binary asset name
- **PR #35 should also publish `update.sh` as `op-env-update`** release asset (flagged in this PR, implemented in #35)

## Review Checklist (from REVIEW_CRITERIA.md)

### Tier 1 — BLOCKING
- [ ] **B1: No secret exfiltration** — update.sh handles only the op-env binary, no secrets
- [ ] **B2: TTY preservation** — `bin/op-env` is not modified. `exec "$@"` untouched.
- [ ] **B3: Shellcheck clean** — update.sh passes shellcheck

### Tier 2 — FLAGGED
- [ ] **F1: Complexity growth** — ~3 lines added to install.sh (49 -> 52 lines, ~6% growth). Proportionate.
- [ ] **F2: New external commands** — `gh` used only in update.sh (repo root) and installed as op-env-update (not in `bin/*`). Does not trigger F2.

### Tier 3 — REVIEW
- [ ] **R1: Fail-closed** — Every error path exits non-zero before state mutation. Atomic tmpfile+mv.
- [ ] **R2: Backwards compatible** — No changes to `bin/op-env`. Existing usage unaffected.
- [ ] **R3: Proportionate** — ~50 lines for update script + 3 lines in install.sh. Completes the release-first pipeline.
- [ ] **R4: No chezmoi conflict** — update.sh at repo root, installed to `~/.local/bin/op-env-update` (same managed path as op-env).

## Status

**Plan-only draft** — no implementation code yet. Waiting for design review.

- Runtime dependency on Component 2 (PR #35). Cannot be tested until a release with binary assets is cut.
- Component 2 should be updated to also publish `op-env-update` as a release asset.
