### PR TITLE
feat: release workflow binary publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,41 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release-please.outputs.release_created }}
+      tag_name: ${{ steps.release-please.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release-please
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+  publish-binary:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build production binary
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          VERSION="${TAG#v}"
+          cp bin/op-env op-env
+          chmod +x op-env
+          # Bake version (same sed pattern as install.sh)
+          sed -i "s|cat \"\$SCRIPT_DIR/../version.txt\" 2>/dev/null|echo \"$VERSION\"|" op-env
+          # Verify version was baked — fail if sed pattern didn't match
+          # shellcheck disable=SC2016
+          if grep -q 'cat "\$SCRIPT_DIR/../version.txt"' op-env; then
+            echo "ERROR: version baking failed" >&2
+            exit 1
+          fi
+          echo "Built op-env binary with version $VERSION"
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          gh release upload "$TAG" op-env --clobber


### PR DESCRIPTION
## Summary

**Part of #24** — Component 2 of 3 (release binary publishing).

Add a `publish-binary` job to `release.yml` that runs after release-please creates a release. It copies `bin/op-env`, bakes the version (same sed logic as `install.sh`), verifies the bake, and uploads the binary as a release asset. This makes GitHub Releases the single source of truth for production binaries.

## Motivation

Component 1 (PR #32) prevents accidental installs from dev state. But without release assets, there's no official binary to download. This component closes that gap — every release automatically publishes a production-ready binary with the version baked in.

## Design

### Changes to `release.yml`

The current release-please step lacks an `id:` field, so its outputs can't be referenced. This PR adds `id: release-please` and propagates outputs at the job level, then chains a new `publish-binary` job.

```yaml
name: Release
on:
  push:
    branches: [main]

permissions:
  contents: write
  pull-requests: write

jobs:
  release-please:
    runs-on: ubuntu-latest
    outputs:
      release_created: ${{ steps.release-please.outputs.release_created }}
      tag_name: ${{ steps.release-please.outputs.tag_name }}
    steps:
      - uses: googleapis/release-please-action@v4
        id: release-please
        with:
          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

  publish-binary:
    runs-on: ubuntu-latest
    needs: release-please
    if: ${{ needs.release-please.outputs.release_created }}
    steps:
      - uses: actions/checkout@v4

      - name: Build production binary
        run: |
          TAG="${{ needs.release-please.outputs.tag_name }}"
          VERSION="${TAG#v}"
          cp bin/op-env op-env
          chmod +x op-env
          sed -i "s|cat \"\$SCRIPT_DIR/../version.txt\" 2>/dev/null|echo \"$VERSION\"|" op-env
          # Verify version was baked — fail if sed pattern didn't match
          if grep -q 'cat "\$SCRIPT_DIR/../version.txt"' op-env; then
            echo "ERROR: version baking failed" >&2
            exit 1
          fi
          # Verify baked version is correct
          echo "Built op-env binary with version $VERSION"

      - name: Upload release asset
        env:
          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
        run: |
          TAG="${{ needs.release-please.outputs.tag_name }}"
          gh release upload "$TAG" op-env --clobber
```

### Version Baking Logic

Reuses the same sed pattern from `install.sh`:
- Source pattern: `cat "$SCRIPT_DIR/../version.txt" 2>/dev/null`
- Baked result: `echo "0.4.3"` (or whatever the release version is)
- Verification: grep for the unbaked pattern — if still present, the bake failed

On Ubuntu CI, `sed -i` works without the `.bak` extension (unlike macOS where `install.sh` uses `sed -i.bak`).

## Key Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Version source | `tag_name` output (strip `v` prefix) | More reliable than reading `version.txt` — it's the actual tag release-please created |
| Asset name | `op-env` (plain, no version suffix) | Simpler for Component 3's download logic. Version is baked inside the binary. |
| `id:` on release-please step | Added `id: release-please` | Required to reference outputs — current release.yml lacks this |
| Job-level outputs | Propagated `release_created` and `tag_name` | Needed for cross-job `needs` conditional |
| Token for upload | `RELEASE_PLEASE_TOKEN` | Same token already used for release-please; has `contents: write` |
| `--clobber` flag | Yes | Idempotent — re-running the workflow replaces the asset safely |
| Checksum file | No | Disproportionate for a bash script. Can add later if needed. |

## Edge Cases

| Scenario | Behavior |
|----------|----------|
| release-please doesn't create a release | `publish-binary` job skipped via `if: release_created` |
| Upload fails | Job fails, release exists but without binary asset. Release is still usable (source code is there). Re-run the workflow to retry. |
| Re-running the workflow | `--clobber` overwrites existing asset. Safe and idempotent. |
| sed pattern changes in bin/op-env | Bake verification catches it — grep for the old pattern fails the build. Forces update of the sed command. |
| version.txt and tag_name disagree | We use `tag_name` exclusively — `version.txt` is not read in this job. |

## Test Strategy

This is a CI workflow — it can't be unit tested locally. Validation plan:

1. **Pre-merge**: Review the YAML for correctness, verify output wiring matches release-please-action@v4 docs
2. **Post-merge dry run**: After merge, the next push to main that doesn't trigger a release will verify the `release-please` job runs without error (publish-binary will be skipped)
3. **Integration test**: Cut an actual release (merge a `feat:` or `fix:` commit). Verify:
   - release-please creates the release
   - `publish-binary` job runs
   - Release has an `op-env` asset attached
   - Downloaded asset has the correct baked version (`./op-env --version`)
4. **Failure test**: Temporarily break the sed pattern to verify the bake check catches it

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Add `id` to release-please step, add `outputs` block, add `publish-binary` job |

## Asset Name Contract

**Component 2 publishes the asset as `op-env`.** Component 3 (update mechanism, PR #34) downloads using this same name. Both PRs must agree on this. If the name changes here, it must change in Component 3.

## Review Checklist (from REVIEW_CRITERIA.md)

### Tier 1 — BLOCKING
- [ ] **B1**: No secret exfiltration — workflow only copies and transforms the public script, no secrets involved
- [ ] **B2**: TTY preservation — `bin/op-env` is not modified in the repo. The release asset is a copy with baked version.
- [ ] **B3**: Shellcheck clean — no changes to scripts in `bin/`. Workflow YAML is not shellchecked.

### Tier 2 — FLAGGED
- [ ] **F1**: Complexity growth — no changes to `bin/*`. Workflow growth is not measured by F1.
- [ ] **F2**: New external commands — no changes to `bin/*`. `gh` is used only in the CI workflow.

### Tier 3 — REVIEW
- [ ] **R1**: Fail-closed — bake verification exits non-zero if pattern isn't replaced. Upload failure fails the job.
- [ ] **R2**: Backwards compatible — existing release.yml behavior unchanged when no release is created. Release-please action is not modified, only given an `id`.
- [ ] **R3**: Proportionate — ~25 lines of YAML for automated binary publishing. Directly enables Component 3.
- [ ] **R4**: No chezmoi conflict — only modifies a CI workflow file.

## Status

**Plan-only draft** — no implementation code yet. Waiting for design review before implementing.

**Asset name contract with Component 3**: Both this PR and PR #34 agree on asset name `op-env`.